### PR TITLE
Verify Certificate Using Port 80

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # free-ssl
-This script will help you to generate a trusted SSL certificate issued by [Let's Encrypt](letsencrypt.org) using [certbot](https://github.com/certbot/certbot) for your Shift node.<br>
+This script will help you generate a trusted SSL certificate issued by [Let's Encrypt](letsencrypt.org) for your Shift node using [certbot](https://github.com/certbot/certbot).<br>
 
 ## Prerequisites
 In order to complete this script, you will need:

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # free-ssl
-This script will help you generate a trusted SSL certificate issued by Let's Encrypt for your Shift node using certbot.<br>
+This script will help you generate a trusted SSL certificate issued by [Let's Encrypt](https://letsencrypt.org) for your [Shift](https://shiftproject.com) node using [certbot](https://certbot.eff.org).<br>
 
 ## Prerequisites
 In order to complete this script, you will need:
-* Have a working [Shift](https://shiftproject.com) instance
+* Have a working [Shift](https://shiftnrl.nl/docs) instance
 * Your own domain. Your domain will look something like this --> `subdomain.domain.tk`
 * An [A Record](https://my.freenom.com/knowledgebase.php?action=displayarticle&id=4) that points your domain to the public IP address of your server
 * To know your network interface

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ This script will help you generate a trusted SSL certificate issued by [Let's En
 
 ## Prerequisites
 In order to complete this script, you will need:
-* Have a working [Shift](https://shiftnrl.nl/docs) instance
+* Have a working [Shift](https://shiftnrg.nl/docs) instance
 * Your own domain. Your domain will look something like this --> `subdomain.domain.tk`
 * An [A Record](https://my.freenom.com/knowledgebase.php?action=displayarticle&id=4) that points your domain to the public IP address of your server
 * To know your network interface

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ This script will help you to generate a trusted SSL certificate issued by [Let's
 
 ## Prerequisites
 In order to complete this script, you will need:
-* Have a working [Shift](docs.shiftnrg.net) instance
+* Have a working [Shift](https://shiftproject.com) instance
 * Your own domain. Your domain will look something like this --> `subdomain.domain.tk`
 * An [A Record](https://my.freenom.com/knowledgebase.php?action=displayarticle&id=4) that points your domain to the public IP address of your server
 * To know your network interface

--- a/README.md
+++ b/README.md
@@ -43,4 +43,4 @@ ACME working area in github: https://github.com/ietf-wg-acme/acme <br><br>
 Original script: https://github.com/mrgrshift/free-ssl.git <br>
 
 
-This script was forked from one created by nytrobound in order to get around the 'Client with the currently selected authenticator does not support any combination of challenges that will satisfy the CA' error. This error emerged in January, 2018, when Let's Encrypt disabling TLS-SNI-01 challenges for security reasons. However, they later released Certbot 0.21.0, that does allow HTTP-01 challenges, and therefore allows this script to run succesfully.
+This script was forked from one created by [nytrobound](https://github.com/nytrobound/free-ssl) in order to get around the 'Client with the currently selected authenticator does not support any combination of challenges that will satisfy the CA' error. This error emerged in January, 2018, when Let's Encrypt disabling TLS-SNI-01 challenges for security reasons. However, they later released Certbot 0.21.0, that does allow HTTP-01 challenges, and therefore allows this script to run succesfully.

--- a/README.md
+++ b/README.md
@@ -43,4 +43,4 @@ ACME working area in github: https://github.com/ietf-wg-acme/acme <br><br>
 Original script: https://github.com/mrgrshift/free-ssl.git <br>
 
 
-This script was forked from one created by [nytrobound](https://github.com/nytrobound/free-ssl) in order to get around the 'Client with the currently selected authenticator does not support any combination of challenges that will satisfy the CA' error. This error emerged in January, 2018, when Let's Encrypt disabling TLS-SNI-01 challenges for security reasons. However, they later released Certbot 0.21.0, that does allow HTTP-01 challenges, and therefore allows this script to run succesfully.
+This script was forked from one created by [nytrobound](https://github.com/nytrobound/free-ssl) in order to get around the 'Client with the currently selected authenticator does not support any combination of challenges that will satisfy the CA' error. This error emerged in January, 2018, when Let's Encrypt disabled TLS-SNI-01 challenges for security reasons. However, they later released Certbot 0.21.0, that does allow HTTP-01 challenges, and therefore allows this script to run succesfully.

--- a/README.md
+++ b/README.md
@@ -41,3 +41,6 @@ ACME spec: http://ietf-wg-acme.github.io/acme/ <br>
 ACME working area in github: https://github.com/ietf-wg-acme/acme <br><br>
 
 Original script: https://github.com/mrgrshift/free-ssl.git <br>
+
+
+This script was forked from one created by nytrobound in order to get around the 'Client with the currently selected authenticator does not support any combination of challenges that will satisfy the CA' error. This error emerged in January, 2018, when Let's Encrypt disabling TLS-SNI-01 challenges for security reasons. However, they later released Certbot 0.21.0, that does allow HTTP-01 challenges, and therefore allows this script to run succesfully.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # free-ssl
-This script will help you generate a trusted SSL certificate issued by [Let's Encrypt](letsencrypt.org) for your Shift node using [certbot](https://github.com/certbot/certbot).<br>
+This script will help you generate a trusted SSL certificate issued by Let's Encrypt for your Shift node using certbot.<br>
 
 ## Prerequisites
 In order to complete this script, you will need:

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ In order to complete this script, you will need:
 First of all you'll need to clone this repository:
 ```
 cd ~
-git clone https://github.com/nytrobound/free-ssl.git
+git clone https://github.com/terrabellus/free-ssl.git
 cd free-ssl
 ```
 To generate and install the trusted SSL certificate, run: `bash installssl.sh`<br>

--- a/README.md
+++ b/README.md
@@ -4,8 +4,7 @@ This script will help you to generate a trusted SSL certificate issued by [Let's
 ## Prerequisites
 In order to complete this script, you will need:
 * Have a working [Shift](docs.shiftnrg.net) instance
-* Your own domain. You can get a free one for one year at [dot.tk](dot.tk)
-	* Your domain will look something like this --> `subdomain.domain.tk`
+* Your own domain. Your domain will look something like this --> `subdomain.domain.tk`
 * An [A Record](https://my.freenom.com/knowledgebase.php?action=displayarticle&id=4) that points your domain to the public IP address of your server
 * To know your network interface
 	* Run `ifconfig` and write it down (normally it is eth0, eth1, eth2, ens1, ens2, ens3...) <br>
@@ -21,7 +20,7 @@ To generate and install the trusted SSL certificate, run: `bash installssl.sh`<b
 The script will guide you through the installation process.<br>
 
 ## Renew Let's Encrypt certificate
-`renewssl.sh` checks the expiring date of your certificate and renew it, if the expiration date is less than 30 days. However, you will need to add a cronjob with `crontab -e` to automatically execute the script.<br>
+`renewssl.sh` checks the expiry date of your certificate and renews it if the expiration date is less than 30 days. However, you will need to add a cronjob with `crontab -e` to automatically execute the script.<br>
 
 Make sure to replace **$SSLUSER** with the username you ran the script on!<br><br>
 
@@ -41,6 +40,3 @@ ACME spec: http://ietf-wg-acme.github.io/acme/ <br>
 ACME working area in github: https://github.com/ietf-wg-acme/acme <br><br>
 
 Original script: https://github.com/mrgrshift/free-ssl.git <br>
-
-
-This script was forked from one created by [nytrobound](https://github.com/nytrobound/free-ssl) in order to get around the 'Client with the currently selected authenticator does not support any combination of challenges that will satisfy the CA' error. This error emerged in January, 2018, when Let's Encrypt disabled TLS-SNI-01 challenges for security reasons. However, they later released Certbot 0.21.0, that does allow HTTP-01 challenges, and therefore allows this script to run succesfully.

--- a/installssl.sh
+++ b/installssl.sh
@@ -15,6 +15,7 @@ echo
 if [ -f "config.sh" ]; then
 	echo "A previous installation was detected. " | tee -a $LOG
 	echo "This script is meant to be executed only once. " | tee -a $LOG
+	echo "If you wish to remove and reinstall, enter 'remove /etc/letsencrypt/live/$DOMAIN' and rerun 'bash installssl.sh'. " | tee -a $LOG 
 	echo "Exiting... " | tee -a $LOG
 	exit 0
 fi

--- a/installssl.sh
+++ b/installssl.sh
@@ -30,7 +30,7 @@ echo -n "Enter the port you will use for HTTPS (default is 9406 for testnet and 
 echo
 echo -e "Before proceeding, please check your ufw configuration. To do this, execute ${CYAN}sudo ufw status${OFF} in a new terminal on your server. "
 echo "You'll need to have your own ports enable, especially your SSH port and your SHIFT client port. "
-echo -e "Execute ${CYAN}ifconfig${OFF} in the other terminal and look for the network interface of your server (normally is eth0, eth1, eth2, ens1, ens2, ens3...) "
+echo -e "Execute ${CYAN}ifconfig${OFF} in the other terminal and look for the network interface of your server (usually, it's eth0, eth1, eth2, ens1, ens2 or ens3...) "
 echo -n "What is your network interface?: "
         read NETWORK_INTERFACE
 echo
@@ -132,7 +132,7 @@ echo
 echo " Your SSL Certificate has been created successfully, now you need to perform the following tasks manually: " | tee -a $LOG
 echo "########################################################################################################" | tee -a $LOG
 echo
-echo "Go to your Shift config.json file and edit the ssl section like the following: " | tee -a $LOG
+echo "Go to your Shift config.json file and edit the ssl section to the following: " | tee -a $LOG
 echo "    \"ssl\": {" | tee -a $LOG
 echo -e "        \"enabled\": ${CYAN}true${OFF},"
 echo "        \"enabled\": true," >> $LOG
@@ -160,4 +160,3 @@ echo "It is recommended that you use https://www.crontab-generator.org/ to help 
 echo "* 12 * * WED bash /home/$SSLUSER/free-ssl/start_renew.sh >> /home/$SSLUSER/free-ssl/logs/cron.log" | tee -a $LOG
 echo "This cronjob checks and renews your SSL certificate every Wednesday at 12pm." | tee -a $LOG
 echo " " | tee -a $LOG
-

--- a/installssl.sh
+++ b/installssl.sh
@@ -25,7 +25,7 @@ echo -n "Enter your domain name: "
 	read DOMAIN_NAME
 echo -n "Enter your email: "
         read EMAIL
-echo -n "Enter the port you will use for HTTPS: "
+echo -n "Enter the port you will use for HTTPS (default is 9406 for testnet and 9306 for mainnet): "
         read HTTPS_PORT
 echo
 echo -e "Before proceeding, please check your ufw configuration. To do this, execute ${CYAN}sudo ufw status${OFF} in a new terminal on your server. "
@@ -61,8 +61,8 @@ export LC_ALL="en_US.UTF-8" >> $LOG
 export LC_CTYPE="en_US.UTF-8" >> $LOG
 
 echo
-echo -n "Generating new SSL certificate.. This could take some minutes.. " | tee -a $LOG
-sudo certbot certonly --standalone -d $DOMAIN_NAME --email $EMAIL --agree-tos --non-interactive &>> $LOG || { echo "Could not generate SSL certificate. Please read your logs/installssl.log file. Exiting. " | tee -a $LOG && exit 1; }
+echo -n "Generating a new SSL certificate.. This could take several minutes.. " | tee -a $LOG
+sudo certbot certonly --standalone --preferred-challenges http -d $DOMAIN_NAME --email $EMAIL --agree-tos --non-interactive &>> $LOG || { echo "Could not generate an SSL certificate. Please read your logs/installssl.log file. Exiting. " | tee -a $LOG && exit 1; }
 echo "Done. " | tee -a $LOG
 sudo chmod 755 /etc/letsencrypt/archive/
 sudo chmod 755 /etc/letsencrypt/live/
@@ -87,7 +87,7 @@ echo "NETWORK_INTERFACE=\"$NETWORK_INTERFACE\"" >> $CONF
 echo
 echo "Please do the following in another terminal on the server: "
 echo -e "Run: ${CYAN}sudo nano /etc/ufw/before.rules${OFF} "
-echo "Go to the bottom of the file and check your last 4 lines, that should look like this: "
+echo "Go to the bottom of the file and check the last 4 lines. They should look like this: "
 echo
 echo "    *nat"
 echo "    :PREROUTING ACCEPT [0:0]"
@@ -127,7 +127,7 @@ echo "* Be aware that if the /etc/ufw/before.rules file contains other types of 
 
 echo
 echo
-echo " Your SSL Certificate has been created successfully, now you need to perform the following manual task: " | tee -a $LOG
+echo " Your SSL Certificate has been created successfully, now you need to perform the following tasks manually: " | tee -a $LOG
 echo "########################################################################################################" | tee -a $LOG
 echo
 echo "Go to your Shift config.json file and edit the ssl section like the following: " | tee -a $LOG
@@ -154,7 +154,7 @@ echo
 echo "You can now visit your address https://$DOMAIN_NAME and confirm the result. " | tee -a $LOG
 echo " "  | tee -a $LOG
 echo
-echo "It is recommended to use https://www.crontab-generator.org/ to help generating a cronjob. You can then add that with crontab -e. Example: " | tee -a $LOG
+echo "It is recommended that you use https://www.crontab-generator.org/ to help generating a cronjob. You can then add that with crontab -e. Example: " | tee -a $LOG
 echo "* 12 * * WED bash /home/$SSLUSER/free-ssl/start_renew.sh >> /home/$SSLUSER/free-ssl/logs/cron.log" | tee -a $LOG
 echo "This cronjob checks and renews your SSL certificate every Wednesday at 12pm." | tee -a $LOG
 echo " " | tee -a $LOG

--- a/installssl.sh
+++ b/installssl.sh
@@ -40,8 +40,9 @@ echo "Your https port is: $HTTPS_PORT " >> $LOG
 echo "Your network interface is: $NETWORK_INTERFACE " >> $LOG
 
 echo
-echo -n "Enabling port 443/tcp.. " | tee -a $LOG
+echo -n "Enabling ports 80/tcp and 443/tcp.. " | tee -a $LOG
 sudo ufw allow 443/tcp &>> $LOG || { echo "Could not enable port 443. Please read your logs/installssl.log file. Exiting. "  | tee -a $LOG && exit 1; }
+sudo ufw allow 80/tcp &>> $LOG || { echo "Could not enable port 80. Please read your logs/installssl.log file. Exiting. "  | tee -a $LOG && exit 1; }
 echo "Done. "
 echo
 echo -n "Backing up firewall.. " | tee -a $LOG
@@ -109,8 +110,9 @@ echo "* Be aware that if the /etc/ufw/before.rules file contains other types of 
 		echo "source config.sh" >> start_renew.sh
 		echo "bash renewssl.sh \$1" >> start_renew.sh
 
-		echo "Deleting allow 443/tcp rule.. " >> $LOG
+		echo "Deleting allow 443/tcp and 80/tcp rules.. " >> $LOG
 		sudo ufw delete allow 443/tcp &>> $LOG || { echo "Could not remove allow 443/tcp rule. Please read your logs/installssl.log file. Exiting. " | tee -a $LOG && exit 1; }
+		sudo ufw delete allow 80/tcp &>> $LOG || { echo "Could not remove allow 80/tcp rule. Please read your logs/installssl.log file. Exiting. " | tee -a $LOG && exit 1; }
 		echo "Allowing your https port $HTTPS_PORT/tcp.. " >> $LOG
 		sudo ufw allow $HTTPS_PORT/tcp &>> $LOG || { echo "Could not allow $HTTPS_PORT/tcp rule. Please read your logs/installssl.log file. Exiting. " | tee -a $LOG && exit 1; }
 		echo "ufw reload.. " >> $LOG

--- a/renewssl.sh
+++ b/renewssl.sh
@@ -33,7 +33,7 @@ else
   echo "This certificate does not exist or could not be successfully renewed. You can do the following: " >> $LOG
   echo " * Check if your domain is still alive. " >> $LOG
   echo " * Check if the folder /etc/letsencrypt/live/$DOMAIN/ exists and it contain *.pem files. " >> $LOG
-  echo " * If nothing of the above works, remove /etc/letsencrypt/live/$DOMAIN/ and run the installer again: bash installssl.sh " >> $LOG
+  echo " * If none of the above works, remove /etc/letsencrypt/live/$DOMAIN/ and run the installer again: bash installssl.sh " >> $LOG
 fi
 echo " " >> $LOG
 
@@ -71,7 +71,7 @@ echo
 echo "Reload firewall.. " >> $LOG
 sudo ufw reload >> $LOG
 echo "Done. " >> $LOG
-echo "Reload Shift to take the new certificate! " >> $LOG
+echo "Reload Shift to activate the new certificate! " >> $LOG
 bash /home/$SSLUSER/shift/shift_manager.bash reload >> $LOG
 echo "Done. " >> $LOG
 TIME=$(date "+DATE: %Y-%m-%d%nTIME: %H:%M:%S")


### PR DESCRIPTION
In order to get around the 'Client with the currently selected authenticator does not support any combination of challenges that will satisfy the CA' error that emerged in January, 2018, when Let's Encrypt disabled TLS-SNI-01 challenges for security reasons, this permits HTTP-01 challenges - allowing the script to run successfully.

Some additional information for the person running the script was also incorporated.